### PR TITLE
Add ext-mbstring to list of requires

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,9 @@
 	"homepage": "http://simplehtmldom.sourceforge.net/",
 	"type": "library",
 	"version": "1.5",
-	"require":{
-		"php":">=5.2.4"
+	"require": {
+		"php": ">=5.2.4",
+		"ext-mbstring": "*"
 	},
 	"authors": [
 		{
@@ -16,7 +17,7 @@
 		}
 	],
 	"autoload": {
-		"classmap":["simple_html_dom.php"],
+		"classmap": ["simple_html_dom.php"],
 		"files": ["simple_html_dom.php"]
 	}
 }


### PR DESCRIPTION
The mbstring extension isn't enabled by default in PHP, so this dependency should be declared so that "composer install" will display an appropriate message, avoiding a runtime failure (and when it eventually gets extension install capabilities via Pickle or similar, it could even enable mbstring automatically).
