### PR TITLE
Remove version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
 	"keywords": ["dom", "php dom"],
 	"homepage": "http://simplehtmldom.sourceforge.net/",
 	"type": "library",
-	"version": "1.5",
 	"require": {
 		"php": ">=5.2.4",
 		"ext-mbstring": "*"


### PR DESCRIPTION
The version of the package. In most cases this is not required and should be omitted (https://getcomposer.org/doc/04-schema.md#version).